### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vosechu/lpena_neighborhood_map/security/code-scanning/3](https://github.com/vosechu/lpena_neighborhood_map/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for all jobs. Based on the workflow's operations, the `contents: read` permission is sufficient, as the jobs only need to read the repository contents for static analysis, linting, and testing. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
